### PR TITLE
Make field PublicIpAddress optional

### DIFF
--- a/providers/elbv2/elbsvc/ec2.go
+++ b/providers/elbv2/elbsvc/ec2.go
@@ -79,9 +79,11 @@ func (svc *ELBService) LookupInstancesByFilter(filters []*ec2.Filter) ([]*EC2Ins
 			instance := &EC2Instance{
 				ID:               *ec2instance.InstanceId,
 				PrivateIPAddress: *ec2instance.PrivateIpAddress,
-				PublicIPAddress:  *ec2instance.PublicIpAddress,
 				SubnetID:         *ec2instance.SubnetId,
 				SecurityGroups:   securityGroups,
+			}
+			if ec2instance.PublicIpAddress != nil {
+				instance.PublicIPAddress = *ec2instance.PublicIpAddress
 			}
 			if ec2instance.VpcId != nil {
 				instance.VpcID = *ec2instance.VpcId


### PR DESCRIPTION
It is impossible to use elbv2 if rancher hosts have private IPs only at the moment.
It's also mentioned here:
https://github.com/rancher/rancher/issues/5959#issuecomment-252524017